### PR TITLE
relax case sensitive comparison for 'project' tag key

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ProjectListView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ProjectListView.tsx
@@ -26,11 +26,11 @@ export const filterExperimentsByProject = (experiments:any, selectedProject:any)
       return experiments;
   } else if (selectedProject === "Default") {
       return experiments.filter(
-          (experiment:any) => !experiment.tags || !experiment.tags.some((tag:any) => tag.key === "project")
+          (experiment:any) => !experiment.tags || !experiment.tags.some((tag:any) => tag.key.toLowerCase() === "project")
       );
   } else {
       return experiments.filter(
-          (experiment:any) => experiment.tags && experiment.tags.some((tag:any) => tag.key === "project" && tag.value === selectedProject)
+          (experiment:any) => experiment.tags && experiment.tags.some((tag:any) => tag.key.toLowerCase() === "project" && tag.value === selectedProject)
       );
   }
 }
@@ -40,11 +40,11 @@ export class ProjectListView extends Component<Props, State> {
     const { experiments } = this.props;
     const projects = experiments
       .filter(experiment => {
-        const projectTag = experiment.tags && experiment.tags.find((tag :any) => tag.key === "project");
+        const projectTag = experiment.tags && experiment.tags.find((tag :any) => tag.key.toLowerCase() === "project");
         return projectTag !== undefined;
       })
       .map(experiment => {
-        const projectTag = experiment.tags.find((tag:any) => tag.key === "project");
+        const projectTag = experiment.tags.find((tag:any) => tag.key.toLowerCase() === "project");
         return projectTag ? projectTag.value : null;
       });
       return ['All','Default', ...new Set(projects)];


### PR DESCRIPTION
Altos raised issue of experiments filter not working when they tag experiments with "Project" key and some tag value. They expect 'Project' key to considered during filter so that experiments are filtered properly for projects which are tagged with 'Project' key. 
Our project filtering code always assumes project key to "project"(all small letters) however altos expected key to flexible enough to make filter work for keys like "project", "Project" etc.

This fixes project filter code always use lower case value of tag to compare with "project" so that capital letter Project key string is also considered during filter.