### PR TITLE
metric-charts-sampling-fix

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/models/ExperimentPageUIState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/models/ExperimentPageUIState.tsx
@@ -47,7 +47,7 @@ export enum RUNS_VISIBILITY_MODE {
 }
 
 export type RunsChartsGlobalLineChartConfig = Partial<
-  Pick<RunsChartsLineCardConfig, 'selectedXAxisMetricKey' | 'xAxisKey' | 'lineSmoothness'>
+  Pick<RunsChartsLineCardConfig, 'selectedXAxisMetricKey' | 'xAxisKey' | 'lineSmoothness'> & { maxResults?: number }
 >;
 
 /**

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/models/ExperimentPageUIState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/models/ExperimentPageUIState.tsx
@@ -47,7 +47,7 @@ export enum RUNS_VISIBILITY_MODE {
 }
 
 export type RunsChartsGlobalLineChartConfig = Partial<
-  Pick<RunsChartsLineCardConfig, 'selectedXAxisMetricKey' | 'xAxisKey' | 'lineSmoothness'> & { maxResults?: number }
+  Pick<RunsChartsLineCardConfig, 'selectedXAxisMetricKey' | 'xAxisKey' | 'lineSmoothness' | 'displayPoints'> & { maxResults?: number }
 >;
 
 /**

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.tsx
@@ -1,11 +1,8 @@
 import {
-  Button,
   Empty,
   Input,
-  RefreshIcon,
   SearchIcon,
   Spacer,
-  Spinner,
   TableSkeleton,
   ToggleButton,
   useDesignSystemTheme,
@@ -79,16 +76,18 @@ const RunViewMetricChartsImpl = ({
   latestMetrics = {},
   params = {},
   tags = {},
+  maxSteps,
+  setMaxSteps,
 }: RunViewMetricChartsProps & {
   chartUIState: ExperimentRunsChartsUIConfiguration;
   updateChartsUIState: (
     stateSetter: (state: ExperimentRunsChartsUIConfiguration) => ExperimentRunsChartsUIConfiguration,
   ) => void;
+  maxSteps: number;
+  setMaxSteps: (value: number) => void;
 }) => {
   const { theme } = useDesignSystemTheme();
   const [search, setSearch] = useState('');
-  const prevSample = localStorage.getItem('mlflow-run-chart-default-samples') || '320'
-  const [maxSteps, setMaxSteps] = useState(parseInt(prevSample, 10));
   const [showPoint, setShowPoint] = useState(false);
   const { formatMessage } = useIntl();
   const maxSamples = [320, 500, 1000, 2500];
@@ -125,11 +124,6 @@ const RunViewMetricChartsImpl = ({
     imagesByRunUuid: state.entities.imagesByRunUuid,
   }));
 
-  const anyRunRefreshing = useSelector((store: ReduxState) => {
-    return values(store.entities.sampledMetricsByRunUuid[runInfo.runUuid ?? '']).some((metricsByRange) =>
-      values(metricsByRange).some(({ refreshing }) => refreshing),
-    );
-  });
 
   const [configuredCardConfig, setConfiguredCardConfig] = useState<RunsChartsCardConfig | null>(null);
 
@@ -153,12 +147,6 @@ const RunViewMetricChartsImpl = ({
     setConfiguredCardConfig(null);
   };
 
-  // Refresh function for charts
-  const refreshCharts = () => {
-    // This would trigger a refresh of all charts
-    // For now, we'll just do nothing since the actual refresh logic depends on the chart implementation
-    // TODO: Implement actual chart refresh logic
-  };
 
   // Create a single run data object to be used in charts
   const chartData: RunsChartsRunData[] = useMemo(
@@ -305,22 +293,6 @@ const RunViewMetricChartsImpl = ({
             onChange={() => setShowPoint(!showPoint)}
           />
         </div>
-        <Button
-          componentId="codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewmetriccharts.tsx_176"
-          icon={
-            anyRunRefreshing ? <Spinner size="small" /> : <RefreshIcon />
-          }
-          onClick={() => {
-            if (!anyRunRefreshing) {
-              refreshCharts();
-            }
-          }}
-        >
-          <FormattedMessage
-            defaultMessage="Refresh"
-            description="Run page > Charts tab > Refresh all charts button label"
-          />
-        </Button>
         {shouldEnableRunDetailsPageAutoRefresh() && (
           <ToggleButton
             componentId="codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewmetricchartsv2.tsx_244"
@@ -402,6 +374,9 @@ export const RunViewMetricCharts = (props: RunViewMetricChartsProps) => {
     [persistenceIdentifier],
   );
 
+  const prevSample = localStorage.getItem('mlflow-run-chart-default-samples') || '320'
+  const [maxSteps, setMaxSteps] = useState(parseInt(prevSample, 10));
+
   const [chartUIState, updateChartsUIState] = useState<ExperimentRunsChartsUIConfiguration>(() => {
     const defaultChartState: ExperimentRunsChartsUIConfiguration = {
       isAccordionReordered: false,
@@ -413,6 +388,7 @@ export const RunViewMetricCharts = (props: RunViewMetricChartsProps) => {
         xAxisKey: RunsChartsLineChartXAxisType.STEP,
         lineSmoothness: 0,
         selectedXAxisMetricKey: '',
+        maxResults: maxSteps,
       },
     };
     try {
@@ -431,9 +407,20 @@ export const RunViewMetricCharts = (props: RunViewMetricChartsProps) => {
     localStore.setItem('chartUIState', JSON.stringify(chartUIState));
   }, [chartUIState, localStore]);
 
+  // Update globalLineChartConfig when maxSteps changes
+  useEffect(() => {
+    updateChartsUIState((current) => ({
+      ...current,
+      globalLineChartConfig: {
+        ...current.globalLineChartConfig,
+        maxResults: maxSteps,
+      },
+    }));
+  }, [maxSteps, updateChartsUIState]);
+
   return (
     <RunsChartsUIConfigurationContextProvider updateChartsUIState={updateChartsUIState}>
-      <RunViewMetricChartsImpl {...props} chartUIState={chartUIState} updateChartsUIState={updateChartsUIState} />
+      <RunViewMetricChartsImpl {...props} chartUIState={chartUIState} updateChartsUIState={updateChartsUIState} maxSteps={maxSteps} setMaxSteps={setMaxSteps} />
     </RunsChartsUIConfigurationContextProvider>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.tsx
@@ -1,11 +1,24 @@
 import {
+  Button,
+  Empty,
+  Input,
+  RefreshIcon,
+  SearchIcon,
+  Spacer,
+  Spinner,
   TableSkeleton,
   ToggleButton,
   useDesignSystemTheme,
+  DialogCombobox,
+  DialogComboboxContent,
+  DialogComboboxOptionList,
+  DialogComboboxOptionListSelectItem,
+  DialogComboboxTrigger,
+  Switch,
 } from '@databricks/design-system';
 import { compact, mapValues, values } from 'lodash';
-import { ReactNode, useEffect, useMemo, useState } from 'react';
-import { useIntl } from 'react-intl';
+import React, { ReactNode, useEffect, useMemo, useState } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import { ReduxState } from '../../../redux-types';
 import type { KeyValueEntity, MetricEntitiesByName, RunInfoEntity } from '../../types';
@@ -75,9 +88,10 @@ const RunViewMetricChartsImpl = ({
   const { theme } = useDesignSystemTheme();
   const [search, setSearch] = useState('');
   const prevSample = localStorage.getItem('mlflow-run-chart-default-samples') || '320'
-  const [maxSteps, setMaxSteps] = useState(parseInt(prevSample));
+  const [maxSteps, setMaxSteps] = useState(parseInt(prevSample, 10));
   const [showPoint, setShowPoint] = useState(false);
   const { formatMessage } = useIntl();
+  const maxSamples = [320, 500, 1000, 2500];
 
   const { compareRunCharts, compareRunSections, chartsSearchFilter } = chartUIState;
 
@@ -111,6 +125,12 @@ const RunViewMetricChartsImpl = ({
     imagesByRunUuid: state.entities.imagesByRunUuid,
   }));
 
+  const anyRunRefreshing = useSelector((store: ReduxState) => {
+    return values(store.entities.sampledMetricsByRunUuid[runInfo.runUuid ?? '']).some((metricsByRange) =>
+      values(metricsByRange).some(({ refreshing }) => refreshing),
+    );
+  });
+
   const [configuredCardConfig, setConfiguredCardConfig] = useState<RunsChartsCardConfig | null>(null);
 
   const reorderCharts = useReorderRunsChartsFn();
@@ -131,6 +151,13 @@ const RunViewMetricChartsImpl = ({
 
     // Hide the modal
     setConfiguredCardConfig(null);
+  };
+
+  // Refresh function for charts
+  const refreshCharts = () => {
+    // This would trigger a refresh of all charts
+    // For now, we'll just do nothing since the actual refresh logic depends on the chart implementation
+    // TODO: Implement actual chart refresh logic
   };
 
   // Create a single run data object to be used in charts
@@ -233,6 +260,67 @@ const RunViewMetricChartsImpl = ({
         }}
       >
         <RunsChartsFilterInput chartsSearchFilter={chartsSearchFilter} />
+        <DialogCombobox
+          componentId="codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewmetriccharts.tsx_samples"
+          label={formatMessage({
+            defaultMessage: 'Samples',
+            description: 'Number of Samples to render',
+          })}
+          value={[maxSteps.toString()]}
+        >
+          <DialogComboboxTrigger allowClear={false} data-testid="max-samples" />
+          <DialogComboboxContent>
+            <DialogComboboxOptionList>
+              {maxSamples.map((sample) => {
+                return (
+                  <DialogComboboxOptionListSelectItem
+                    checked={maxSteps === sample}
+                    key={sample}
+                    data-testid={'max-samples-' + sample}
+                    value={sample.toString()}
+                    onChange={() => {
+                      setMaxSteps(sample);
+                      localStorage.setItem('mlflow-run-chart-default-samples', sample.toString());
+                    }}
+                  >
+                    {sample}
+                  </DialogComboboxOptionListSelectItem>
+                );
+              })}
+            </DialogComboboxOptionList>
+          </DialogComboboxContent>
+        </DialogCombobox>
+        <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
+          <div>
+            <FormattedMessage
+              defaultMessage="Points:"
+              // eslint-disable-next-line max-len
+              description="Label for the toggle button to toggle to show points or not for the metric experiment run"
+            />
+          </div>
+          <Switch
+            componentId="codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewmetriccharts.tsx_show-point"
+            data-testid="show-point-toggle"
+            defaultChecked={showPoint}
+            onChange={() => setShowPoint(!showPoint)}
+          />
+        </div>
+        <Button
+          componentId="codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewmetriccharts.tsx_176"
+          icon={
+            anyRunRefreshing ? <Spinner size="small" /> : <RefreshIcon />
+          }
+          onClick={() => {
+            if (!anyRunRefreshing) {
+              refreshCharts();
+            }
+          }}
+        >
+          <FormattedMessage
+            defaultMessage="Refresh"
+            description="Run page > Charts tab > Refresh all charts button label"
+          />
+        </Button>
         {shouldEnableRunDetailsPageAutoRefresh() && (
           <ToggleButton
             componentId="codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewmetricchartsv2.tsx_244"

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewMetricCharts.tsx
@@ -78,6 +78,8 @@ const RunViewMetricChartsImpl = ({
   tags = {},
   maxSteps,
   setMaxSteps,
+  showPoint,
+  setShowPoint,
 }: RunViewMetricChartsProps & {
   chartUIState: ExperimentRunsChartsUIConfiguration;
   updateChartsUIState: (
@@ -85,10 +87,11 @@ const RunViewMetricChartsImpl = ({
   ) => void;
   maxSteps: number;
   setMaxSteps: (value: number) => void;
+  showPoint: boolean;
+  setShowPoint: (value: boolean) => void;
 }) => {
   const { theme } = useDesignSystemTheme();
   const [search, setSearch] = useState('');
-  const [showPoint, setShowPoint] = useState(false);
   const { formatMessage } = useIntl();
   const maxSamples = [320, 500, 1000, 2500];
 
@@ -376,6 +379,7 @@ export const RunViewMetricCharts = (props: RunViewMetricChartsProps) => {
 
   const prevSample = localStorage.getItem('mlflow-run-chart-default-samples') || '320'
   const [maxSteps, setMaxSteps] = useState(parseInt(prevSample, 10));
+  const [showPoint, setShowPoint] = useState(false);
 
   const [chartUIState, updateChartsUIState] = useState<ExperimentRunsChartsUIConfiguration>(() => {
     const defaultChartState: ExperimentRunsChartsUIConfiguration = {
@@ -389,6 +393,7 @@ export const RunViewMetricCharts = (props: RunViewMetricChartsProps) => {
         lineSmoothness: 0,
         selectedXAxisMetricKey: '',
         maxResults: maxSteps,
+        displayPoints: showPoint,
       },
     };
     try {
@@ -407,20 +412,21 @@ export const RunViewMetricCharts = (props: RunViewMetricChartsProps) => {
     localStore.setItem('chartUIState', JSON.stringify(chartUIState));
   }, [chartUIState, localStore]);
 
-  // Update globalLineChartConfig when maxSteps changes
+  // Update globalLineChartConfig when maxSteps or showPoint changes
   useEffect(() => {
     updateChartsUIState((current) => ({
       ...current,
       globalLineChartConfig: {
         ...current.globalLineChartConfig,
         maxResults: maxSteps,
+        displayPoints: showPoint,
       },
     }));
-  }, [maxSteps, updateChartsUIState]);
+  }, [maxSteps, showPoint, updateChartsUIState]);
 
   return (
     <RunsChartsUIConfigurationContextProvider updateChartsUIState={updateChartsUIState}>
-      <RunViewMetricChartsImpl {...props} chartUIState={chartUIState} updateChartsUIState={updateChartsUIState} maxSteps={maxSteps} setMaxSteps={setMaxSteps} />
+      <RunViewMetricChartsImpl {...props} chartUIState={chartUIState} updateChartsUIState={updateChartsUIState} maxSteps={maxSteps} setMaxSteps={setMaxSteps} showPoint={showPoint} setShowPoint={setShowPoint} />
     </RunsChartsUIConfigurationContextProvider>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/cards/RunsChartsLineChartCard.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/cards/RunsChartsLineChartCard.tsx
@@ -97,7 +97,7 @@ export const RunsChartsLineChartCard = ({
   positionInSection,
   ...reorderProps
 }: RunsChartsLineChartCardProps) => {
-  const { xAxisKey, selectedXAxisMetricKey, lineSmoothness } = useLineChartGlobalConfig(config, globalLineChartConfig);
+  const { xAxisKey, selectedXAxisMetricKey, lineSmoothness, maxResults } = useLineChartGlobalConfig(config, globalLineChartConfig);
 
   const toggleFullScreenChart = useCallback(() => {
     setFullScreenChart?.({
@@ -191,7 +191,7 @@ export const RunsChartsLineChartCard = ({
     runUuids: runUuidsToFetch,
     metricKeys,
     enabled: isInViewportDeferred,
-    maxResults: 320,
+    maxResults: maxResults || 320,
     range: stepRange,
     autoRefreshEnabled,
   });

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/cards/RunsChartsLineChartCard.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/cards/RunsChartsLineChartCard.tsx
@@ -97,7 +97,7 @@ export const RunsChartsLineChartCard = ({
   positionInSection,
   ...reorderProps
 }: RunsChartsLineChartCardProps) => {
-  const { xAxisKey, selectedXAxisMetricKey, lineSmoothness, maxResults } = useLineChartGlobalConfig(config, globalLineChartConfig);
+  const { xAxisKey, selectedXAxisMetricKey, lineSmoothness, maxResults, displayPoints } = useLineChartGlobalConfig(config, globalLineChartConfig);
 
   const toggleFullScreenChart = useCallback(() => {
     setFullScreenChart?.({
@@ -339,7 +339,7 @@ export const RunsChartsLineChartCard = ({
           xRange={xRangeLocal}
           yRange={yRangeLocal}
           fullScreen={fullScreen}
-          displayPoints={config.displayPoints}
+          displayPoints={displayPoints}
           onSetDownloadHandler={setImageDownloadHandler}
           positionInSection={positionInSection ?? 0}
         />

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/config/RunsChartsConfigureLineChart.preview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/config/RunsChartsConfigureLineChart.preview.tsx
@@ -75,7 +75,7 @@ const RunsChartsConfigureLineChartPreviewImpl = ({
     runUuids: runUuidsToFetch,
     metricKeys: metricKeysToFetch,
     enabled: true,
-    maxResults: 320,
+    maxResults: globalLineChartConfig?.maxResults || 320,
     autoRefreshEnabled: false,
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/hooks/useLineChartGlobalConfig.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/hooks/useLineChartGlobalConfig.tsx
@@ -13,7 +13,7 @@ export const useLineChartGlobalConfig = (
   globalLineChartConfig?: RunsChartsGlobalLineChartConfig,
 ) =>
   useMemo(() => {
-    const result = pick(originalCardConfig, ['xAxisKey', 'selectedXAxisMetricKey', 'lineSmoothness']);
+    const result = pick(originalCardConfig, ['xAxisKey', 'selectedXAxisMetricKey', 'lineSmoothness', 'displayPoints']);
 
     if (!globalLineChartConfig) {
       return result;
@@ -31,6 +31,11 @@ export const useLineChartGlobalConfig = (
       if (globalXAxisKey === RunsChartsLineChartXAxisType.METRIC && globalSelectedXAxisMetricKey) {
         result.selectedXAxisMetricKey = globalSelectedXAxisMetricKey;
       }
+    }
+
+    // Add displayPoints if available in global config
+    if (!isUndefined(globalLineChartConfig.displayPoints)) {
+      result.displayPoints = globalLineChartConfig.displayPoints;
     }
 
     // Add maxResults if available in global config

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/hooks/useLineChartGlobalConfig.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/hooks/useLineChartGlobalConfig.tsx
@@ -33,5 +33,10 @@ export const useLineChartGlobalConfig = (
       }
     }
 
+    // Add maxResults if available in global config
+    if (!isUndefined(globalLineChartConfig.maxResults)) {
+      (result as any).maxResults = globalLineChartConfig.maxResults;
+    }
+
     return result;
   }, [originalCardConfig, globalLineChartConfig]);


### PR DESCRIPTION
metric-charts-sampling-fix
1. Added dropdown to change sampling

<img width="1512" height="982" alt="Screenshot 2025-09-11 at 3 24 24 PM" src="https://github.com/user-attachments/assets/0786037e-3c4f-4a28-bd72-1fe606221eec" />
<img width="1512" height="982" alt="Screenshot 2025-09-11 at 3 24 50 PM" src="https://github.com/user-attachments/assets/d169f64e-ac0f-42ea-b79c-eb831c5c82b1" />
